### PR TITLE
--check mode and new fs:touch and fs:chown commands

### DIFF
--- a/bin/droid-fs
+++ b/bin/droid-fs
@@ -3,6 +3,8 @@
 
 use Symfony\Component\Console\Application;
 
+use Droid\Plugin\Fs\DroidPlugin;
+
 $loader = __DIR__ . '/../vendor/autoload.php';
 
 if (!file_exists($loader)) {
@@ -21,10 +23,8 @@ require $loader;
 
 $application = new Application('Droid FS', '1.0.0');
 $application->setCatchExceptions(true);
-$application->add(new Droid\Plugin\Fs\Command\FsChmodCommand());
-$application->add(new Droid\Plugin\Fs\Command\FsCopyCommand());
-$application->add(new Droid\Plugin\Fs\Command\FsMkdirCommand());
-$application->add(new Droid\Plugin\Fs\Command\FsMountCommand());
-$application->add(new Droid\Plugin\Fs\Command\FsRenameCommand());
-$application->add(new Droid\Plugin\Fs\Command\FsTemplateCommand());
+$registry = new DroidPlugin($application);
+foreach ($registry->getCommands() as $command) {
+    $application->add($command);
+}
 $application->run();

--- a/composer.json
+++ b/composer.json
@@ -12,12 +12,15 @@
         }
     ],
     "require": {
-        "php": ">=5.3.0",
+        "php": ">=5.4.0",
         "symfony/console": "~2.7",
         "symfony/process": "~2.7",
+        "droid/libcommand": "^1.0",
         "zordius/lightncandy": "~0.93"
     },
     "require-dev": {
+        "phpunit/phpunit": "^4.8",
+        "mikey179/vfsStream": "^1.6",
         "linkorb/autotune": "~1.0"
     },
     "autoload": {

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -1,0 +1,20 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:noNamespaceSchemaLocation="phpunit.xsd"
+         bootstrap="test/bootstrap.php"
+         backupGlobals="false"
+         verbose="true">
+
+  <testsuites>
+    <testsuite name="droid-fs">
+      <directory suffix="Test.php">test</directory>
+    </testsuite>
+  </testsuites>
+
+  <filter>
+    <whitelist processUncoveredFilesFromWhitelist="true">
+      <directory suffix=".php">src/</directory>
+    </whitelist>
+  </filter>
+
+</phpunit>

--- a/src/Command/FsChmodCommand.php
+++ b/src/Command/FsChmodCommand.php
@@ -6,11 +6,14 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Droid\Lib\Plugin\Command\CheckableTrait;
 use Droid\Plugin\Fs\Utils;
 use RuntimeException;
 
 class FsChmodCommand extends Command
 {
+    use CheckableTrait;
+
     public function configure()
     {
         $this->setName('fs:chmod')
@@ -26,10 +29,12 @@ class FsChmodCommand extends Command
                 'filename to update'
             )
         ;
+        $this->configureCheckMode();
     }
 
     public function execute(InputInterface $input, OutputInterface $output)
     {
+        $this->activateCheckMode($input);
         $filename = $input->getArgument('filename');
         $filename = Utils::normalizePath($filename);
 
@@ -46,8 +51,11 @@ class FsChmodCommand extends Command
 
         $output->writeLn("Fs chmod: " . decoct($mode)  . " $filename");
 
+        $this->markChange();
+        if (!$this->checkMode()) {
+            chmod($filename, $mode);
+        }
 
-        chmod($filename, $mode);
-
+        $this->reportChange($output);
     }
 }

--- a/src/Command/FsChmodCommand.php
+++ b/src/Command/FsChmodCommand.php
@@ -4,7 +4,6 @@ namespace Droid\Plugin\Fs\Command;
 
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Droid\Plugin\Fs\Utils;
@@ -28,7 +27,7 @@ class FsChmodCommand extends Command
             )
         ;
     }
-    
+
     public function execute(InputInterface $input, OutputInterface $output)
     {
         $filename = $input->getArgument('filename');
@@ -44,11 +43,11 @@ class FsChmodCommand extends Command
         if (!file_exists($filename)) {
             throw new RuntimeException("File does not exist: " . $filename);
         }
-        
+
         $output->writeLn("Fs chmod: " . decoct($mode)  . " $filename");
 
 
         chmod($filename, $mode);
-        
+
     }
 }

--- a/src/Command/FsChownCommand.php
+++ b/src/Command/FsChownCommand.php
@@ -1,0 +1,172 @@
+<?php
+namespace Droid\Plugin\Fs\Command;
+
+use RuntimeException;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+use Symfony\Component\Process\ProcessBuilder;
+
+use Droid\Lib\Plugin\Command\CheckableTrait;
+use Droid\Plugin\Fs\Utils;
+use Droid\Plugin\Fs\Service\AclObjectLookupInterface;
+
+class FsChownCommand extends Command
+{
+    use CheckableTrait;
+
+    protected $processBuilder;
+    protected $userLookup;
+
+    public function __construct(
+        AclObjectLookupInterface $userLookup,
+        ProcessBuilder $processBuilder,
+        $name = null
+    ) {
+        $this->userLookup = $userLookup;
+        $this->processBuilder = $processBuilder;
+        return parent::__construct($name);
+    }
+
+    public function configure()
+    {
+        $this
+            ->setName('fs:chown')
+            ->setDescription('Change ownership of a file')
+            ->addArgument(
+                'file',
+                InputArgument::REQUIRED,
+                'Path to file'
+            )
+            ->addArgument(
+                'user',
+                InputArgument::REQUIRED,
+                'User name'
+            )
+            ->addArgument(
+                'group',
+                InputArgument::REQUIRED,
+                'Group name'
+            )
+        ;
+        $this->configureCheckMode();
+    }
+
+    public function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->activateCheckMode($input);
+
+        $path = Utils::normalizePath($input->getArgument('file'));
+
+        if (! file_exists($path)) {
+            throw new RuntimeException(
+                sprintf('The file "%s" does not exist.', $path)
+            );
+        }
+
+        $user = $input->getArgument('user');
+        $uid = $this->userLookup->userId($user);
+        if ($uid === null) {
+            throw new RuntimeException(
+                sprintf(
+                    'Failed to determine user id for a user named "%s". Do they exist?',
+                    $user
+                )
+            );
+        }
+
+        $group = $input->getArgument('group');
+        $gid = $this->userLookup->groupId($group);
+        if ($gid === null) {
+            throw new RuntimeException(
+                sprintf(
+                    'Failed to determine group id for a group named "%s". Does it exist?',
+                    $group
+                )
+            );
+        }
+
+        $stat = stat($path);
+        if ($stat === false) {
+            throw new RuntimeException(
+                sprintf('Cannot stat file "%s".', $path)
+            );
+        }
+        if ($uid === $stat['uid'] && $gid === $stat['gid']) {
+            $output->writeln(
+                sprintf(
+                    'The file "%s" already has the supplied ownership. Nothing to do.',
+                    $path
+                )
+            );
+            $this->reportChange($output);
+            return 0;
+        }
+
+        $this->markChange();
+
+        if ($uid === $stat['uid']) {
+            $output->writeln(
+                sprintf(
+                    'The file "%s" is already owned by user "%s". I will not change user ownership.',
+                    $path,
+                    $user
+                )
+            );
+        }
+        if ($gid === $stat['gid']) {
+            $output->writeln(
+                sprintf(
+                    'The file "%s" is already owned by group "%s". I will not change group ownership.',
+                    $path,
+                    $group
+                )
+            );
+        }
+
+        if ($this->checkMode()) {
+            $output->writeln(sprintf('I would chown file "%s".', $path));
+        } else {
+            $this->chown($user, $group, $path);
+            $output->writeln(sprintf('Chowned file "%s".', $path));
+        }
+
+        $this->reportChange($output);
+    }
+
+    private function chown($user, $group, $path)
+    {
+        if ($this->checkMode()) {
+            return;
+        }
+        $p = $this->getProcess(
+            array(
+                'sudo', #?
+                'chown',
+                sprintf('%s:%s', $user, $group),
+                $path
+            )
+        );
+        if ($p->run()) {
+            throw new RuntimeException(
+                sprintf(
+                    'Failed to change ownership of file "%s": %s',
+                    $path,
+                    trim($p->getErrorOutput())
+                ),
+                $p->getExitCode()
+            );
+        }
+    }
+
+    private function getProcess($arguments)
+    {
+        return $this
+            ->processBuilder
+            ->setArguments($arguments)
+            ->getProcess()
+        ;
+    }
+}

--- a/src/Command/FsCopyCommand.php
+++ b/src/Command/FsCopyCommand.php
@@ -6,10 +6,9 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Droid\Plugin\Fs\Utils;
 use RuntimeException;
 
-class FSCopyCommand extends Command
+class FsCopyCommand extends Command
 {
     public function configure()
     {
@@ -61,7 +60,7 @@ class FSCopyCommand extends Command
         $group = $input->getOption('group');
         $mask = $input->getOption('mask');
         $check = $input->getOption('check');
-        
+
         $changed = false;
 
         //$output->WriteLn("Copying $src to $dest");
@@ -70,12 +69,12 @@ class FSCopyCommand extends Command
                 throw new RuntimeException("Source file does not exist: " . $src);
             }
         }
-        
+
         $dirname = dirname($dest);
         if (!file_exists($dirname) && !in_array($dirname, ['.', '..'])) {
             throw new RuntimeException("Destination directory does not exist: " . $dirname);
         }
-        
+
         if (!file_exists($dest)) {
             if ($output->getVerbosity() >= OutputInterface::VERBOSITY_DEBUG) {
                 $output->writeln('Destination file does not yet exist');
@@ -89,7 +88,7 @@ class FSCopyCommand extends Command
                 $changed = true;
             }
         }
-        
+
         if (!$check) {
             if (!copy($src, $dest)) {
                 throw new RuntimeException("Copy failed: " . $src);
@@ -99,7 +98,7 @@ class FSCopyCommand extends Command
         if (file_exists($dest)) {
             if ($owner) {
                 $currentOwner = posix_getpwuid(fileowner($dest))['name'];
-                
+
                 if ($currentOwner != $owner) {
                     if ($output->getVerbosity() >= OutputInterface::VERBOSITY_DEBUG) {
                         $output->writeln('File ownership differs');
@@ -115,16 +114,16 @@ class FSCopyCommand extends Command
                     }
                 }
             }
-            
+
             if ($group) {
                 $currentGroup = posix_getgrgid(filegroup($dest))['name'];
-                
+
                 if ($currentGroup != $group) {
                     if ($output->getVerbosity() >= OutputInterface::VERBOSITY_DEBUG) {
                         $output->writeln('File group differs');
                     }
                     $changed = true;
-                
+
                     if (!$check) {
                         if (!chgrp($dest, $group)) {
                             throw new RuntimeException("Failed to change group: " . $group);
@@ -132,7 +131,7 @@ class FSCopyCommand extends Command
                     }
                 }
             }
-            
+
             if ($mask) {
                 $currentMask = fileperms($dest);
                 $currentMask = substr(decoct($currentMask), -3);
@@ -141,7 +140,7 @@ class FSCopyCommand extends Command
                         $output->writeln('File mask differs');
                     }
                     $changed = true;
-                    
+
                     if (!$check) {
                         if (!chmod($dest, octdec($mask))) {
                             throw new RuntimeException("Failed to change permission mask: " . $mask);

--- a/src/Command/FsMkdirCommand.php
+++ b/src/Command/FsMkdirCommand.php
@@ -7,11 +7,14 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Droid\Lib\Plugin\Command\CheckableTrait;
 use Droid\Plugin\Fs\Utils;
 use RuntimeException;
 
 class FsMkdirCommand extends Command
 {
+    use CheckableTrait;
+
     public function configure()
     {
         $this->setName('fs:mkdir')
@@ -34,10 +37,12 @@ class FsMkdirCommand extends Command
                 'Force'
             )
         ;
+        $this->configureCheckMode();
     }
 
     public function execute(InputInterface $input, OutputInterface $output)
     {
+        $this->activateCheckMode($input);
         $directory = $input->getArgument('directory');
         $directory = Utils::normalizePath($directory);
         $output->writeLn("Fs mkdir: $directory");
@@ -52,9 +57,13 @@ class FsMkdirCommand extends Command
         } else {
             $mode = octdec($mode);
         }
-        @mkdir($directory, $mode, true);
-        if (!file_exists($directory)) {
-            throw new RuntimeException("Directory creation failed: " . $directory);
+        $this->markChange();
+        if (!$this->checkMode()) {
+            @mkdir($directory, $mode, true);
+            if (!file_exists($directory)) {
+                throw new RuntimeException("Directory creation failed: " . $directory);
+            }
         }
+        $this->reportChange($output);
     }
 }

--- a/src/Command/FsMkdirCommand.php
+++ b/src/Command/FsMkdirCommand.php
@@ -35,7 +35,7 @@ class FsMkdirCommand extends Command
             )
         ;
     }
-    
+
     public function execute(InputInterface $input, OutputInterface $output)
     {
         $directory = $input->getArgument('directory');

--- a/src/Command/FsMountCommand.php
+++ b/src/Command/FsMountCommand.php
@@ -7,13 +7,11 @@ use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
 use Symfony\Component\Process\Process;
-use Symfony\Component\Process\ProcessBuilder;
 use Symfony\Component\Process\Exception\ProcessFailedException;
-use Droid\Plugin\Fs\Utils;
 use Droid\Plugin\Fs\FstabLine;
 use RuntimeException;
 
-class FSMountCommand extends Command
+class FsMountCommand extends Command
 {
     public function configure()
     {
@@ -86,7 +84,7 @@ class FSMountCommand extends Command
         if (!file_exists($fstab)) {
             throw new RuntimeException('fstab file does not exist: ' . $fstab);
         }
-        
+
         $content = file_get_contents($fstab);
         $rows = explode("\n", $content);
         foreach ($rows as $row) {
@@ -95,7 +93,7 @@ class FSMountCommand extends Command
             $lines[] = $line;
         }
         //print_r($lines);
-        
+
         $newLine = null;
         foreach ($lines as $line) {
             if (trim($line->getFileSystem())==$fileSystem) {
@@ -113,7 +111,7 @@ class FSMountCommand extends Command
         $newLine->setOptions($options);
         $newLine->setDump($dump);
         $newLine->setPass($pass);
-        
+
         $o = '';
         foreach ($lines as $line) {
             $o .= $line->render();
@@ -123,7 +121,7 @@ class FSMountCommand extends Command
             file_put_contents($fstab . '.'. date('Y-m-d_H-i-s') . '.backup', $content);
         }
         file_put_contents($fstab, $o);
-        
+
         $cmd = 'mountpoint ' . $newLine->getMountPoint();
         $process = new Process($cmd);
         $process->run();
@@ -131,12 +129,12 @@ class FSMountCommand extends Command
             $output->WriteLn("Already mounted " . $newLine->getMountPoint());
             return 0;
         }
-        
+
         $cmd = 'mount ' . $newLine->getMountPoint();
         $process = new Process($cmd);
         $output->writeLn($process->getCommandLine());
         $process->run();
-        
+
         if (!$process->isSuccessful()) {
             throw new ProcessFailedException($process);
         }

--- a/src/Command/FsRenameCommand.php
+++ b/src/Command/FsRenameCommand.php
@@ -5,10 +5,13 @@ use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Droid\Lib\Plugin\Command\CheckableTrait;
 use RuntimeException;
 
 class FsRenameCommand extends Command
 {
+    use CheckableTrait;
+
     public function configure()
     {
         $this->setName('fs:rename')
@@ -23,10 +26,12 @@ class FsRenameCommand extends Command
                 InputArgument::REQUIRED,
                 'Destination filename or directory'
             );
+        $this->configureCheckMode();
     }
 
     public function execute(InputInterface $input, OutputInterface $output)
     {
+        $this->activateCheckMode($input);
         $src = $input->getArgument('src');
         $dest = $input->getArgument('dest');
 
@@ -43,8 +48,10 @@ class FsRenameCommand extends Command
         if (file_exists($dest)) {
             throw new RuntimeException("Destination already exist: " . $dest);
         }
-        if (!rename($src, $dest)) {
+        $this->markChange();
+        if (!$this->checkMode() && !rename($src, $dest)) {
             throw new RuntimeException("Rename failed: " . $src .' to ' .$dest);
         }
+        $this->reportChange($output);
     }
 }

--- a/src/Command/FsRenameCommand.php
+++ b/src/Command/FsRenameCommand.php
@@ -3,10 +3,8 @@ namespace Droid\Plugin\Fs\Command;
 
 use Symfony\Component\Console\Command\Command;
 use Symfony\Component\Console\Input\InputArgument;
-use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Droid\Plugin\Fs\Utils;
 use RuntimeException;
 
 class FsRenameCommand extends Command

--- a/src/Command/FsTemplateCommand.php
+++ b/src/Command/FsTemplateCommand.php
@@ -7,12 +7,15 @@ use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputOption;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
+use Droid\Lib\Plugin\Command\CheckableTrait;
 use Droid\Plugin\Fs\Utils;
 use RuntimeException;
 use LightnCandy\LightnCandy;
 
 class FsTemplateCommand extends Command
 {
+    use CheckableTrait;
+
     public function configure()
     {
         $this->setName('fs:template')
@@ -46,10 +49,13 @@ class FsTemplateCommand extends Command
                 'Force'
             )
         ;
+        $this->configureCheckMode();
     }
 
     public function execute(InputInterface $input, OutputInterface $output)
     {
+        $this->activateCheckMode($input);
+
         $src = $input->getArgument('src');
         $content = Utils::getContents($src);
 
@@ -63,6 +69,12 @@ class FsTemplateCommand extends Command
             $mode = octdec($mode);
         }
 
+        $this->markChange();
+
+        if ($this->checkMode()) {
+            $this->reportChange();
+            return 0;
+        }
 
         $output->writeLn("Creating file $dest. Mode: " . decoct($mode));
 
@@ -82,5 +94,7 @@ class FsTemplateCommand extends Command
         $content = $render($data);
 
         file_put_contents($dest, $content);
+
+        $this->reportChange($output);
     }
 }

--- a/src/Command/FsTemplateCommand.php
+++ b/src/Command/FsTemplateCommand.php
@@ -47,12 +47,12 @@ class FsTemplateCommand extends Command
             )
         ;
     }
-    
+
     public function execute(InputInterface $input, OutputInterface $output)
     {
         $src = $input->getArgument('src');
         $content = Utils::getContents($src);
-        
+
         $dest = $input->getArgument('dest');
         $dest = Utils::normalizePath($dest);
 
@@ -63,12 +63,12 @@ class FsTemplateCommand extends Command
             $mode = octdec($mode);
         }
 
-        
+
         $output->writeLn("Creating file $dest. Mode: " . decoct($mode));
-        
+
         $php = LightnCandy::compile($content);
         $render = LightnCandy::prepare($php);
-        
+
         $data = [];
         $jsonFilename = $input->getOption('json');
         if ($jsonFilename) {
@@ -78,9 +78,9 @@ class FsTemplateCommand extends Command
                 throw new RuntimeException("Can't parse data as JSON");
             }
         }
-        
+
         $content = $render($data);
-        
+
         file_put_contents($dest, $content);
     }
 }

--- a/src/Command/FsTouchCommand.php
+++ b/src/Command/FsTouchCommand.php
@@ -1,0 +1,165 @@
+<?php
+namespace Droid\Plugin\Fs\Command;
+
+use RuntimeException;
+
+use Symfony\Component\Console\Command\Command;
+use Symfony\Component\Console\Input\InputArgument;
+use Symfony\Component\Console\Input\InputOption;
+use Symfony\Component\Console\Input\InputInterface;
+use Symfony\Component\Console\Output\OutputInterface;
+
+use Droid\Lib\Plugin\Command\CheckableTrait;
+use Droid\Plugin\Fs\Utils;
+
+class FsTouchCommand extends Command
+{
+    use CheckableTrait;
+
+    public function configure()
+    {
+        $this
+            ->setName('fs:touch')
+            ->setDescription('Change file access and modification time')
+            ->addArgument(
+                'file',
+                InputArgument::REQUIRED,
+                'Path to file'
+            )
+            ->addOption(
+                'no-create',
+                null,
+                InputOption::VALUE_NONE,
+                'Do not create a file'
+            )
+            ->addOption(
+                'atime',
+                'a',
+                InputOption::VALUE_REQUIRED,
+                'Set the access time'
+            )
+            ->addOption(
+                'mtime',
+                'm',
+                InputOption::VALUE_REQUIRED,
+                'Set the modification time'
+            )
+        ;
+        $this->configureCheckMode();
+    }
+
+    public function execute(InputInterface $input, OutputInterface $output)
+    {
+        $this->activateCheckMode($input);
+
+        $path = Utils::normalizePath($input->getArgument('file'));
+        $exists = file_exists($path);
+
+        $opt_atime = $input->getOption('atime');
+        $opt_mtime = $input->getOption('mtime');
+
+        if ($exists && ! $opt_atime && ! $opt_mtime) {
+            $output->writeln(
+                sprintf(
+                    'The file "%s" exists and I was not instructed to change a timestamp. Nothing to do.',
+                    $path
+                )
+            );
+            $this->reportChange($output);
+            return 0;
+        } elseif (! $exists && $input->getOption('no-create')) {
+            $output->writeln(
+                sprintf(
+                    'The file "%s" does not exist and I was instructed not to create it. Nothing to do.',
+                    $path
+                )
+            );
+            $this->reportChange($output);
+            return 0;
+        }
+
+        $now = new \DateTime;
+
+        $atime = null;
+        if ($opt_atime && strtolower($opt_atime) == 'now') {
+            $atime = $now->getTimestamp();
+        } elseif ($opt_atime) {
+            try {
+                $atime = new \DateTime($opt_atime);
+                $atime = $atime->getTimestamp();
+            } catch (\Exception $e) {
+                throw new RuntimeException(
+                    sprintf(
+                        'I do not like the look of your atime: %s.',
+                        $e->getMessage()
+                    )
+                );
+            }
+        }
+        $mtime = null;
+        if ($opt_mtime && strtolower($opt_mtime) == 'now') {
+            $mtime = $now->getTimestamp();
+        } elseif ($opt_mtime) {
+            try {
+                $mtime = new \DateTime($opt_mtime);
+                $mtime = $mtime->getTimestamp();
+            } catch (\Exception $e) {
+                throw new RuntimeException(
+                    sprintf(
+                        'I do not like the look of your mtime: %s.',
+                        $e->getMessage()
+                    )
+                );
+            }
+        }
+
+        if (! $exists) {
+            $this->markChange();
+        } else {
+            $stat = stat($path);
+            if ($stat === false) {
+                throw new RuntimeException(
+                    sprintf('Cannot stat file "%s".', $path)
+                );
+            }
+            if ($atime && $atime !== $stat['atime']) {
+                $this->markChange();
+            } elseif (!$atime) {
+                // preserve atime
+                $atime = $stat['atime'];
+            }
+            if ($mtime && $mtime !== $stat['mtime']) {
+                $this->markChange();
+            } elseif (!$mtime) {
+                // preserve mtime
+                $mtime = $stat['mtime'];
+            }
+            if (!$this->wouldChange()) {
+                $output->writeln(
+                    sprintf(
+                        'The file "%s" already has the supplied timestamps. Nothing to do.',
+                        $path
+                    )
+                );
+                $this->reportChange($output);
+                return 0;
+            }
+            $this->markChange();
+        }
+
+        if ($this->checkMode()) {
+            $this->reportChange($output);
+            return 0;
+        }
+
+        $touched = touch($path, $mtime, $atime);
+        if (!$touched) {
+            throw new RuntimeException(
+                sprintf('Failed to touch file "%s".', $path)
+            );
+        }
+
+        $output->writeln(sprintf('Touched file "%s".', $path));
+        $this->reportChange($output);
+    }
+}

--- a/src/DroidPlugin.php
+++ b/src/DroidPlugin.php
@@ -8,7 +8,7 @@ class DroidPlugin
     {
         $this->droid = $droid;
     }
-    
+
     public function getCommands()
     {
         $commands = [];
@@ -19,6 +19,7 @@ class DroidPlugin
         $commands[] = new \Droid\Plugin\Fs\Command\FsMountCommand();
         $commands[] = new \Droid\Plugin\Fs\Command\FsRenameCommand();
         $commands[] = new \Droid\Plugin\Fs\Command\FsTemplateCommand();
+        $commands[] = new \Droid\Plugin\Fs\Command\FsTouchCommand();
         return $commands;
     }
 }

--- a/src/DroidPlugin.php
+++ b/src/DroidPlugin.php
@@ -2,6 +2,11 @@
 
 namespace Droid\Plugin\Fs;
 
+use Symfony\Component\Process\ProcessBuilder;
+
+use Droid\Plugin\Fs\Command\FsChownCommand;
+use Droid\Plugin\Fs\Service\PosixAclObjectLookup;
+
 class DroidPlugin
 {
     public function __construct($droid)
@@ -14,6 +19,10 @@ class DroidPlugin
         $commands = [];
 
         $commands[] = new \Droid\Plugin\Fs\Command\FsChmodCommand();
+        $commands[] = new FsChownCommand(
+            new PosixAclObjectLookup,
+            new ProcessBuilder
+        );
         $commands[] = new \Droid\Plugin\Fs\Command\FsCopyCommand();
         $commands[] = new \Droid\Plugin\Fs\Command\FsMkdirCommand();
         $commands[] = new \Droid\Plugin\Fs\Command\FsMountCommand();

--- a/src/Service/AclObjectLookupInterface.php
+++ b/src/Service/AclObjectLookupInterface.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Droid\Plugin\Fs\Service;
+
+interface AclObjectLookupInterface
+{
+    /**
+     * Lookup user id by user name.
+     *
+     * @param string $name
+     *
+     * @return null|integer
+     */
+    public function userId($name);
+
+    /**
+     * Lookup user name by user id.
+     *
+     * @param int $id
+     *
+     * @return null|string
+     */
+    public function userName($id);
+
+    /**
+     * Lookup group id by group name.
+     *
+     * @param string $name
+     *
+     * @return null|integer
+     */
+    public function groupId($name);
+
+    /**
+     * Lookup group name by group id.
+     *
+     * @param int $id
+     *
+     * @return null|string
+     */
+    public function groupName($id);
+}

--- a/src/Service/PosixAclObjectLookup.php
+++ b/src/Service/PosixAclObjectLookup.php
@@ -1,0 +1,42 @@
+<?php
+
+namespace Droid\Plugin\Fs\Service;
+
+class PosixAclObjectLookup implements AclObjectLookupInterface
+{
+    public function userId($name)
+    {
+        $info = posix_getpwnam($name);
+        if ($info === false || !isset($info['uid']) || !is_numeric($info['uid'])) {
+            return null;
+        }
+        return (int) $info['uid'];
+    }
+
+    public function userName($id)
+    {
+        $info = posix_getpwuid($id);
+        if ($info === false || !isset($info['name']) || !is_numeric($info['name'])) {
+            return null;
+        }
+        return (string) $info['name'];
+    }
+
+    public function groupId($name)
+    {
+        $info = posix_getgrnam($name);
+        if ($info === false || !isset($info['gid']) || !is_numeric($info['gid'])) {
+            return null;
+        }
+        return (int) $info['gid'];
+    }
+
+    public function groupName($id)
+    {
+        $info = posix_getgrid($id);
+        if ($info === false || !isset($info['name']) || !is_numeric($info['name'])) {
+            return null;
+        }
+        return (string) $info['name'];
+    }
+}

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -21,7 +21,7 @@ class Utils
         }
         return $path;
     }
-    
+
     public static function getContents($filename)
     {
         if (substr($filename, 0, 5) == 'data:') {

--- a/src/Utils.php
+++ b/src/Utils.php
@@ -8,6 +8,9 @@ class Utils
 {
     public static function normalizePath($path)
     {
+        if (preg_match('@^\w+://@', $path)) {
+            return $path; // has a scheme, e.g. "file://"
+        }
         switch ($path[0]) {
             case '/':
                 break;

--- a/test/Command/FsChownCommandTest.php
+++ b/test/Command/FsChownCommandTest.php
@@ -1,0 +1,507 @@
+<?php
+
+namespace Droid\Test\Plugin\Fs\Command;
+
+use \RuntimeException;
+
+use org\bovigo\vfs\vfsStream;
+use org\bovigo\vfs\vfsStreamDirectory;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+use Symfony\Component\Process\Process;
+use Symfony\Component\Process\ProcessBuilder;
+
+use Droid\Plugin\Fs\Command\FsChownCommand;
+use Droid\Plugin\Fs\Service\AclObjectLookupInterface;
+
+class FsChownCommandTest extends \PHPUnit_Framework_TestCase
+{
+    protected $app;
+    protected $lookup;
+    protected $process;
+    protected $processBuilder;
+    protected $tester;
+    protected $vfs;
+
+    protected function setUp()
+    {
+        $this->process = $this
+            ->getMockBuilder(Process::class)
+            ->disableOriginalConstructor()
+            ->setMethods(array('run', 'getErrorOutput', 'getExitCode'))
+            ->getMock()
+        ;
+        $this->processBuilder = $this
+            ->getMockBuilder(ProcessBuilder::class)
+            ->setMethods(array('setArguments', 'getProcess'))
+            ->getMock()
+        ;
+        $this->processBuilder
+            ->method('getProcess')
+            ->willReturn($this->process)
+        ;
+        $this->processBuilder
+            ->method('setArguments')
+            ->willReturnSelf()
+        ;
+        $this->lookup = $this
+            ->getMockBuilder(AclObjectLookupInterface::class)
+            ->getMock()
+        ;
+
+        $command = new FsChownCommand($this->lookup, $this->processBuilder);
+
+        $this->app = new Application;
+        $this->app->add($command);
+
+        $this->tester = new CommandTester($command);
+
+        $this->vfs = vfsStream::setup();
+    }
+
+    protected function tearDown()
+    {
+        clearstatcache();
+    }
+
+    /**
+     * @expectedException RuntimeException
+     * @expectedExceptionMessage The file "vfs://root/some_file" does not exist
+     */
+    public function testChownThrowsExceptionWhenTheFileDoesNotExist()
+    {
+        $this->tester->execute(array(
+            'command' => $this->app->find('fs:chown')->getName(),
+            'file' => vfsStream::url('root/some_file'),
+            'user' => 'a_user',
+            'group' => 'a_group',
+        ));
+    }
+
+    /**
+     * @expectedException RuntimeException
+     * @expectedExceptionMessage Failed to determine user id for a user named "a_user"
+     */
+    public function testChownThrowsExceptionWhenUidIsNotFound()
+    {
+        vfsStream::newFile('some_file')->at($this->vfs);
+
+        $this
+            ->lookup
+            ->expects($this->once())
+            ->method('userId')
+            ->with('a_user')
+            ->willReturn(null)
+        ;
+        $this
+            ->lookup
+            ->expects($this->never())
+            ->method('groupId')
+        ;
+
+        $this->tester->execute(array(
+            'command' => $this->app->find('fs:chown')->getName(),
+            'file' => vfsStream::url('root/some_file'),
+            'user' => 'a_user',
+            'group' => 'a_group',
+        ));
+    }
+
+    /**
+     * @expectedException RuntimeException
+     * @expectedExceptionMessage Failed to determine group id for a group named "a_group"
+     */
+    public function testChownThrowsExceptionWhenGidIsNotFound()
+    {
+        vfsStream::newFile('some_file')->at($this->vfs);
+
+        $this
+            ->lookup
+            ->expects($this->once())
+            ->method('userId')
+            ->with('a_user')
+            ->willReturn(1000)
+        ;
+        $this
+            ->lookup
+            ->expects($this->once())
+            ->method('groupId')
+            ->with('a_group')
+            ->willReturn(null)
+        ;
+
+        $this->tester->execute(array(
+            'command' => $this->app->find('fs:chown')->getName(),
+            'file' => vfsStream::url('root/some_file'),
+            'user' => 'a_user',
+            'group' => 'a_group',
+        ));
+    }
+
+    public function testChownDoesNothingWhenSuppliedOwnershipsMatchExisting()
+    {
+        $user = 'a_user';
+        $group = 'a_group';
+
+        vfsStream::newFile('some_file')
+            ->at($this->vfs)
+            ->setContent('hello!')
+            ->chown($user)
+            ->chgrp($group)
+        ;
+        $stat = stat(vfsStream::url('root/some_file'));
+
+        $this
+            ->lookup
+            ->expects($this->once())
+            ->method('userId')
+            ->with('a_user')
+            ->willReturn($stat['uid'])
+        ;
+
+        $this
+            ->lookup
+            ->expects($this->once())
+            ->method('groupId')
+            ->with('a_group')
+            ->willReturn($stat['gid'])
+        ;
+
+        $this->tester->execute(array(
+            'command' => $this->app->find('fs:chown')->getName(),
+            'file' => vfsStream::url('root/some_file'),
+            'user' => $user,
+            'group' => $group,
+        ));
+
+        $this->assertRegExp(
+            '/^The file "[^"]*" already has the supplied ownership. Nothing to do/',
+            $this->tester->getDisplay()
+        );
+    }
+
+    public function testChownChangesOnlyUserOwnershipWhenGroupOwnershipMatchesArg()
+    {
+        # set up a file to chown and
+        vfsStream::newFile('some_file')
+            ->at($this->vfs)
+            ->setContent('hello!')
+            ->chown('a_user')
+            ->chgrp('a_group')
+        ;
+        $path = vfsStream::url('root/some_file');
+        $stat = stat($path);
+        $original_uid = $stat['uid'];
+        $original_gid = $stat['gid'];
+
+        # set up user and group who will become owner
+        $expected_user = 'other_user';
+        $expected_uid = $original_uid + 1; # the new owner has a different uid
+        $expected_group = 'a_group';       # the group owner isn't changing
+
+        $this
+            ->lookup
+            ->expects($this->once())
+            ->method('userId')
+            ->with($expected_user)
+            ->willReturn($expected_uid)
+        ;
+        $this
+            ->lookup
+            ->expects($this->once())
+            ->method('groupId')
+            ->with($expected_group)
+            ->willReturn($original_gid) # same as the present file owner gid
+        ;
+        $this
+            ->processBuilder
+            ->expects($this->once())
+            ->method('setArguments')
+            ->with(
+                array(
+                    'sudo',
+                    'chown',
+                    sprintf('%s:%s', $expected_user, $expected_group),
+                    $path
+                )
+            )
+        ;
+        $this
+            ->process
+            ->method('run')
+            ->willReturn(0)
+        ;
+
+        $this->tester->execute(array(
+            'command' => $this->app->find('fs:chown')->getName(),
+            'file' => $path,
+            'user' => $expected_user,
+            'group' => $expected_group,
+        ));
+
+        $this->assertRegExp(
+            '/^The file "[^"]*" is already owned by group "a_group". I will not change group ownership/',
+            $this->tester->getDisplay()
+        );
+        $this->assertRegExp(
+            '/Chowned file "[^"]*"/',
+            $this->tester->getDisplay()
+        );
+    }
+
+    public function testChownChangesOnlyGroupOwnershipWhenUserOwnershipMatchesArg()
+    {
+        vfsStream::newFile('some_file')
+            ->at($this->vfs)
+            ->setContent('hello!')
+            ->chown('a_user')
+            ->chgrp('a_group')
+        ;
+        $path = vfsStream::url('root/some_file');
+        $stat = stat($path);
+        $original_uid = $stat['uid'];
+        $original_gid = $stat['gid'];
+
+        $expected_user = 'a_user';         # the user owner isn't changing
+        $expected_group = 'other_group';
+        $expected_gid = $original_gid + 1; # the group owner has a different gid
+
+        $this
+            ->lookup
+            ->expects($this->once())
+            ->method('userId')
+            ->with($expected_user)
+            ->willReturn($original_uid) # same as the present file owner gid
+        ;
+        $this
+            ->lookup
+            ->expects($this->once())
+            ->method('groupId')
+            ->with($expected_group)
+            ->willReturn($expected_gid)
+        ;
+        $this
+            ->processBuilder
+            ->expects($this->once())
+            ->method('setArguments')
+            ->with(
+                array(
+                    'sudo',
+                    'chown',
+                    sprintf('%s:%s', $expected_user, $expected_group),
+                    $path
+                )
+            )
+        ;
+        $this
+            ->process
+            ->method('run')
+            ->willReturn(0)
+        ;
+
+        $this->tester->execute(array(
+            'command' => $this->app->find('fs:chown')->getName(),
+            'file' => $path,
+            'user' => $expected_user,
+            'group' => $expected_group,
+        ));
+
+        $this->assertRegExp(
+            '/^The file "[^"]*" is already owned by user "a_user". I will not change user ownership/',
+            $this->tester->getDisplay()
+        );
+        $this->assertRegExp(
+            '/Chowned file "[^"]*"/',
+            $this->tester->getDisplay()
+        );
+    }
+
+    /**
+     * @expectedException RuntimeException
+     * @expectedExceptionMessage Failed to change ownership of file
+     */
+    public function testChownThrowsExceptionWhenItFailsToChangesOwnership()
+    {
+        vfsStream::newFile('some_file')
+            ->at($this->vfs)
+            ->setContent('hello!')
+            ->chown('a_user')
+            ->chgrp('a_group')
+        ;
+        $path = vfsStream::url('root/some_file');
+        $stat = stat($path);
+        $original_uid = $stat['uid'];
+        $original_gid = $stat['gid'];
+
+        $expected_user = 'a_user';
+        $expected_group = 'other_group';
+        $expected_uid = $original_uid + 1;
+        $expected_gid = $original_gid + 1;
+
+        $this
+            ->lookup
+            ->expects($this->once())
+            ->method('userId')
+            ->with($expected_user)
+            ->willReturn($expected_uid)
+        ;
+        $this
+            ->lookup
+            ->expects($this->once())
+            ->method('groupId')
+            ->with($expected_group)
+            ->willReturn($expected_gid)
+        ;
+        $this
+            ->processBuilder
+            ->expects($this->once())
+            ->method('setArguments')
+            ->with(
+                array(
+                    'sudo',
+                    'chown',
+                    sprintf('%s:%s', $expected_user, $expected_group),
+                    $path
+                )
+            )
+        ;
+        $this
+            ->process
+            ->method('run')
+            ->willReturn(1)
+        ;
+        $this
+            ->process
+            ->method('getErrorOutput')
+            ->willReturn('For some reason or other.')
+        ;
+
+        $this->tester->execute(array(
+            'command' => $this->app->find('fs:chown')->getName(),
+            'file' => $path,
+            'user' => $expected_user,
+            'group' => $expected_group,
+        ));
+    }
+
+    public function testChownChangesOwnership()
+    {
+        vfsStream::newFile('some_file')
+            ->at($this->vfs)
+            ->setContent('hello!')
+            ->chown('a_user')
+            ->chgrp('a_group')
+        ;
+        $path = vfsStream::url('root/some_file');
+        $stat = stat($path);
+        $original_uid = $stat['uid'];
+        $original_gid = $stat['gid'];
+
+        $expected_user = 'a_user';
+        $expected_group = 'other_group';
+        $expected_uid = $original_uid + 1;
+        $expected_gid = $original_gid + 1;
+
+        $this
+            ->lookup
+            ->expects($this->once())
+            ->method('userId')
+            ->with($expected_user)
+            ->willReturn($expected_uid)
+        ;
+        $this
+            ->lookup
+            ->expects($this->once())
+            ->method('groupId')
+            ->with($expected_group)
+            ->willReturn($expected_gid)
+        ;
+        $this
+            ->processBuilder
+            ->expects($this->once())
+            ->method('setArguments')
+            ->with(
+                array(
+                    'sudo',
+                    'chown',
+                    sprintf('%s:%s', $expected_user, $expected_group),
+                    $path
+                )
+            )
+        ;
+        $this
+            ->process
+            ->method('run')
+            ->willReturn(0)
+        ;
+
+        $this->tester->execute(array(
+            'command' => $this->app->find('fs:chown')->getName(),
+            'file' => $path,
+            'user' => $expected_user,
+            'group' => $expected_group,
+        ));
+
+        $this->assertRegExp(
+            '/^Chowned file "[^"]*"/',
+            $this->tester->getDisplay()
+        );
+    }
+
+    public function testChownDoesNotChangeOwnershipInCheckMode()
+    {
+        vfsStream::newFile('some_file')
+            ->at($this->vfs)
+            ->setContent('hello!')
+            ->chown('a_user')
+            ->chgrp('a_group')
+        ;
+        $path = vfsStream::url('root/some_file');
+        $stat = stat($path);
+        $original_uid = $stat['uid'];
+        $original_gid = $stat['gid'];
+
+        $expected_user = 'a_user';
+        $expected_group = 'other_group';
+        $expected_uid = $original_uid + 1;
+        $expected_gid = $original_gid + 1;
+
+        $this
+            ->lookup
+            ->expects($this->once())
+            ->method('userId')
+            ->with($expected_user)
+            ->willReturn($expected_uid)
+        ;
+        $this
+            ->lookup
+            ->expects($this->once())
+            ->method('groupId')
+            ->with($expected_group)
+            ->willReturn($expected_gid)
+        ;
+        $this
+            ->processBuilder
+            ->expects($this->never())
+            ->method('setArguments')
+        ;
+        $this
+            ->process
+            ->expects($this->never())
+            ->method('run')
+        ;
+
+        $this->tester->execute(array(
+            'command' => $this->app->find('fs:chown')->getName(),
+            'file' => $path,
+            'user' => $expected_user,
+            'group' => $expected_group,
+            '--check' => true
+        ));
+
+        $this->assertRegExp(
+            '/^I would chown file "[^"]*"/',
+            $this->tester->getDisplay()
+        );
+    }
+}

--- a/test/Command/FsCommandTest.php
+++ b/test/Command/FsCommandTest.php
@@ -1,0 +1,132 @@
+<?php
+
+namespace Droid\Test\Plugin\Fs\Command;
+
+use org\bovigo\vfs\vfsStream;
+use org\bovigo\vfs\vfsStreamDirectory;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+
+use Droid\Plugin\Fs\Command\FsChmodCommand;
+use Droid\Plugin\Fs\Command\FsCopyCommand;
+use Droid\Plugin\Fs\Command\FsMkdirCommand;
+use Droid\Plugin\Fs\Command\FsMountCommand;
+use Droid\Plugin\Fs\Command\FsRenameCommand;
+use Droid\Plugin\Fs\Command\FsTemplateCommand;
+
+class FsCommandTest extends \PHPUnit_Framework_TestCase
+{
+    protected $app;
+    protected $vfs;
+
+    protected function setUp()
+    {
+        $this->vfs = vfsStream::setup();
+        $this->app = new Application;
+    }
+
+    public function testFsChmodCommandIsSane()
+    {
+        $command = new FsChmodCommand;
+        $tester = new CommandTester($command);
+        $this->app->add($command);
+
+        vfsStream::newFile('some_file')->at($this->vfs)->setContent('hello!');
+
+        $tester->execute(array(
+            'command' => $this->app->find('fs:chmod')->getName(),
+            'filename' => vfsStream::url('root/some_file'),
+            'mode' => 0640
+        ));
+    }
+
+    public function testFsCopyCommandIsSane()
+    {
+        $command = new FSCopyCommand;
+        $tester = new CommandTester($command);
+        $this->app->add($command);
+
+        vfsStream::newFile('some_file')->at($this->vfs)->setContent('hello!');
+
+        $tester->execute(array(
+            'command' => $this->app->find('fs:copy')->getName(),
+            'src' => vfsStream::url('root/some_file'),
+            'dest' => vfsStream::url('root/copy_of_some_file')
+        ));
+    }
+
+    public function testFsMkdirCommandIsSane()
+    {
+        $command = new FsMkdirCommand;
+        $tester = new CommandTester($command);
+        $this->app->add($command);
+
+        vfsStream::newFile('some_file')->at($this->vfs)->setContent('hello!');
+
+        $tester->execute(array(
+            'command' => $this->app->find('fs:mkdir')->getName(),
+            'directory' => vfsStream::url('root/new_dir')
+        ));
+    }
+
+    /**
+     * @expectedException \Symfony\Component\Process\Exception\ProcessFailedException
+     *
+     * We are not mocking Process and so this command is executing `mount` for
+     * real.  It would be better not to execute mount, especially if this test
+     * were doing more than sanity checking the command, but it's not, so we
+     * are, so there.
+     */
+    public function testFsMountCommandIsSane()
+    {
+        $command = new FsMountCommand;
+        $tester = new CommandTester($command);
+        $this->app->add($command);
+
+        vfsStream::create(
+            array(
+                'etc' => array('fstab' => '# /etc/fstab: static file system information.'),
+                'mnt' => array(),
+                'dev' => array('cdrom' => array())
+            )
+        );
+
+        $tester->execute(array(
+            'command' => $this->app->find('fs:mount')->getName(),
+            'filesystem' => vfsStream::url('root/dev/crdrom'),
+            'mount-point' => vfsStream::url('root/mnt/crdrom'),
+            'type' => 'iso9660',
+            '--fstab' => vfsStream::url('root/etc/fstab'),
+        ));
+    }
+
+    public function testFsRenameCommandIsSane()
+    {
+        $command = new FsRenameCommand;
+        $tester = new CommandTester($command);
+        $this->app->add($command);
+
+        vfsStream::newFile('some_file')->at($this->vfs)->setContent('hello!');
+
+        $tester->execute(array(
+            'command' => $this->app->find('fs:rename')->getName(),
+            'src' => vfsStream::url('root/some_file'),
+            'dest' => vfsStream::url('root/some_phile')
+        ));
+    }
+
+    public function testFsTemplateCommandIsSane()
+    {
+        $command = new FsTemplateCommand;
+        $tester = new CommandTester($command);
+        $this->app->add($command);
+
+        vfsStream::newFile('some_template')->at($this->vfs)->setContent('hello!');
+
+        $tester->execute(array(
+            'command' => $this->app->find('fs:template')->getName(),
+            'src' => vfsStream::url('root/some_template'),
+            'dest' => vfsStream::url('root/some_file')
+        ));
+    }
+}

--- a/test/Command/FsTouchCommandTest.php
+++ b/test/Command/FsTouchCommandTest.php
@@ -1,0 +1,289 @@
+<?php
+
+namespace Droid\Test\Plugin\Fs\Command;
+
+use org\bovigo\vfs\vfsStream;
+use org\bovigo\vfs\vfsStreamDirectory;
+use Symfony\Component\Console\Application;
+use Symfony\Component\Console\Tester\CommandTester;
+
+use Droid\Plugin\Fs\Command\FsTouchCommand;
+
+class FsTouchCommandTest extends \PHPUnit_Framework_TestCase
+{
+    protected $app;
+    protected $tester;
+    protected $vfs;
+
+    protected function setUp()
+    {
+        $command = new FsTouchCommand;
+
+        $this->app = new Application;
+        $this->app->add($command);
+
+        $this->tester = new CommandTester($command);
+
+        $this->vfs = vfsStream::setup();
+    }
+
+    public function testTouchWillExitIfNoTimestampsSuppliedAndFileExists()
+    {
+        vfsStream::newFile('some_file')->at($this->vfs)->setContent('hello!');
+
+        $this->tester->execute(array(
+            'command' => $this->app->find('fs:touch')->getName(),
+            'file' => vfsStream::url('root/some_file'),
+        ));
+
+        $this->assertRegExp(
+            '/^The file "[^"]*" exists and I was not instructed to change a timestamp/',
+            $this->tester->getDisplay()
+        );
+    }
+
+    public function testTouchWillExitIfNoCreateAndFileNotExists()
+    {
+        $this->tester->execute(array(
+            'command' => $this->app->find('fs:touch')->getName(),
+            'file' => vfsStream::url('root/some_file'),
+            '--no-create' => true,
+        ));
+
+        $this->assertRegExp(
+            '/^The file "[^"]*" does not exist and I was instructed not to create it/',
+            $this->tester->getDisplay()
+        );
+    }
+
+    /**
+     * @expectedException \RuntimeException
+     * @expectedExceptonMessage I do not like the look of your atime
+     */
+    public function testTouchWithBogusAtimeThrowsRuntimeException()
+    {
+        $this->tester->execute(array(
+            'command' => $this->app->find('fs:touch')->getName(),
+            'file' => vfsStream::url('root/some_file'),
+            '--atime' => '2099-01-99',
+        ));
+    }
+
+    /**
+     * @expectedException \RuntimeException
+     * @expectedExceptonMessage I do not like the look of your mtime
+     */
+    public function testTouchWithBogusMtimeThrowsRuntimeException()
+    {
+        $this->tester->execute(array(
+            'command' => $this->app->find('fs:touch')->getName(),
+            'file' => vfsStream::url('root/some_file'),
+            '--mtime' => '2099-01-99',
+        ));
+    }
+
+    public function testTouchDoesNothingWhenSuppliedTimestampsMatchExisting()
+    {
+        $atime = new \DateTime('Today');
+        $mtime = new \DateTime('Yesterday');
+
+        vfsStream::newFile('some_file')
+            ->at($this->vfs)
+            ->setContent('hello!')
+            ->lastAccessed($atime->getTimestamp())
+            ->lastModified($mtime->getTimestamp())
+        ;
+
+        $this->tester->execute(array(
+            'command' => $this->app->find('fs:touch')->getName(),
+            'file' => vfsStream::url('root/some_file'),
+            '--atime' => $atime->format('c'),
+            '--mtime' => $mtime->format('c'),
+        ));
+
+        $this->assertRegExp(
+            '/^The file "[^"]*" already has the supplied timestamps. Nothing to do/',
+            $this->tester->getDisplay()
+        );
+    }
+
+    public function testTouchUpdatesBothTimestampsWhenBothAreSupplied()
+    {
+        $original_atime = new \DateTime('Today');
+        $original_mtime = new \DateTime('Yesterday');
+
+        $expected_atime = clone $original_atime;
+        $expected_atime->modify('+1 hour');
+
+        $expected_mtime = clone $original_mtime;
+        $expected_mtime->modify('+1 hour');
+
+        vfsStream::newFile('some_file')
+            ->at($this->vfs)
+            ->setContent('hello!')
+            ->lastAccessed($original_atime->getTimestamp())
+            ->lastModified($original_mtime->getTimestamp())
+        ;
+
+        $stat = stat(vfsStream::url('root/some_file'));
+        $this->assertSame(
+            $original_atime->getTimestamp(),
+            $stat['atime'],
+            'The file starts with a known atime'
+        );
+        $this->assertSame(
+            $original_mtime->getTimestamp(),
+            $stat['mtime'],
+            'The file starts with a known mtime'
+        );
+
+        $this->tester->execute(array(
+            'command' => $this->app->find('fs:touch')->getName(),
+            'file' => vfsStream::url('root/some_file'),
+            '--atime' => $expected_atime->format('c'),
+            '--mtime' => $expected_mtime->format('c'),
+        ));
+
+        clearstatcache(true, vfsStream::url('root/some_file'));
+        $stat = stat(vfsStream::url('root/some_file'));
+        $this->assertSame(
+            $expected_atime->getTimestamp(),
+            $stat['atime'],
+            'The touch command updates the atime of the file to the expected value'
+        );
+        $this->assertSame(
+            $expected_mtime->getTimestamp(),
+            $stat['mtime'],
+            'The touch command updates the mtime of the file to the expected value'
+        );
+
+        $this->assertRegExp(
+            '/^Touched file "[^"]*"/',
+            $this->tester->getDisplay()
+        );
+    }
+
+    public function testTouchUpdatesOnlyAtimeWhenOnlyAtimeIsSupplied()
+    {
+        $original_atime = new \DateTime('Today');
+        $original_mtime = new \DateTime('Yesterday');
+
+        $expected_atime = clone $original_atime;
+        $expected_atime->modify('+1 hour');
+
+        $expected_mtime = $original_mtime;
+
+        vfsStream::newFile('some_file')
+            ->at($this->vfs)
+            ->setContent('hello!')
+            ->lastAccessed($original_atime->getTimestamp())
+            ->lastModified($original_mtime->getTimestamp())
+        ;
+
+        $stat = stat(vfsStream::url('root/some_file'));
+        $this->assertSame(
+            $original_atime->getTimestamp(),
+            $stat['atime'],
+            'The file starts with a known atime'
+        );
+        $this->assertSame(
+            $original_mtime->getTimestamp(),
+            $stat['mtime'],
+            'The file starts with a known mtime'
+        );
+
+        $this->tester->execute(array(
+            'command' => $this->app->find('fs:touch')->getName(),
+            'file' => vfsStream::url('root/some_file'),
+            '--atime' => $expected_atime->format('c'),
+        ));
+
+        clearstatcache(true, vfsStream::url('root/some_file'));
+        $stat = stat(vfsStream::url('root/some_file'));
+        $this->assertSame(
+            $expected_atime->getTimestamp(),
+            $stat['atime'],
+            'The touch command updates the atime of the file to the expected value'
+        );
+        $this->assertSame(
+            $expected_mtime->getTimestamp(),
+            $stat['mtime'],
+            'The touch command does not change the mtime'
+        );
+
+        $this->assertRegExp(
+            '/^Touched file "[^"]*"/',
+            $this->tester->getDisplay()
+        );
+    }
+
+    public function testTouchUpdatesOnlyMtimeWhenOnlyMtimeIsSupplied()
+    {
+        $original_atime = new \DateTime('Today');
+        $original_mtime = new \DateTime('Yesterday');
+
+        $expected_atime = $original_atime;
+
+        $expected_mtime = clone $original_mtime;
+        $expected_mtime->modify('+1 hour');
+
+        vfsStream::newFile('some_file')
+            ->at($this->vfs)
+            ->setContent('hello!')
+            ->lastAccessed($original_atime->getTimestamp())
+            ->lastModified($original_mtime->getTimestamp())
+        ;
+
+        $stat = stat(vfsStream::url('root/some_file'));
+        $this->assertSame(
+            $original_atime->getTimestamp(),
+            $stat['atime'],
+            'The file starts with a known atime'
+        );
+        $this->assertSame(
+            $original_mtime->getTimestamp(),
+            $stat['mtime'],
+            'The file starts with a known mtime'
+        );
+
+        $this->tester->execute(array(
+            'command' => $this->app->find('fs:touch')->getName(),
+            'file' => vfsStream::url('root/some_file'),
+            '--mtime' => $expected_mtime->format('c'),
+        ));
+
+        clearstatcache(true, vfsStream::url('root/some_file'));
+        $stat = stat(vfsStream::url('root/some_file'));
+        $this->assertSame(
+            $expected_atime->getTimestamp(),
+            $stat['atime'],
+            'The touch command does not change the atime'
+        );
+        $this->assertSame(
+            $expected_mtime->getTimestamp(),
+            $stat['mtime'],
+            'The touch command updates the mtime of the file to the expected value'
+        );
+
+        $this->assertRegExp(
+            '/^Touched file "[^"]*"/',
+            $this->tester->getDisplay()
+        );
+    }
+
+    public function testTouchCreatesNonExistingFile()
+    {
+        $this->assertFalse($this->vfs->hasChild('some_file'));
+
+        $this->tester->execute(array(
+            'command' => $this->app->find('fs:touch')->getName(),
+            'file' => vfsStream::url('root/some_file')
+        ));
+
+        $this->assertTrue($this->vfs->hasChild('some_file'));
+        $this->assertRegExp(
+            '/^Touched file "[^"]*"/',
+            $this->tester->getDisplay()
+        );
+    }
+}

--- a/test/bootstrap.php
+++ b/test/bootstrap.php
@@ -1,0 +1,5 @@
+<?php
+/**
+ * Require the composer-generated autoloader.
+ */
+$droid_test_autoloader = include __DIR__ . '/../vendor/autoload.php';


### PR DESCRIPTION
For review.

```
phpunit --testdox

Droid\Test\Plugin\Fs\Command\FsChownCommand
 [x] Chown throws exception when the file does not exist
 [x] Chown throws exception when uid is not found
 [x] Chown throws exception when gid is not found
 [x] Chown does nothing when supplied ownerships match existing
 [x] Chown changes only user ownership when group ownership matches arg
 [x] Chown changes only group ownership when user ownership matches arg
 [x] Chown throws exception when it fails to changes ownership
 [x] Chown changes ownership
 [x] Chown does not change ownership in check mode

Droid\Test\Plugin\Fs\Command\FsCommand
 [x] Fs chmod command is sane
 [x] Fs copy command is sane
 [x] Fs mkdir command is sane
 [x] Fs mount command is sane
 [x] Fs rename command is sane
 [x] Fs template command is sane

Droid\Test\Plugin\Fs\Command\FsTouchCommand
 [x] Touch will exit if no timestamps supplied and file exists
 [x] Touch will exit if no create and file not exists
 [x] Touch with bogus atime throws runtime exception
 [x] Touch with bogus mtime throws runtime exception
 [x] Touch does nothing when supplied timestamps match existing
 [x] Touch updates both timestamps when both are supplied
 [x] Touch updates only atime when only atime is supplied
 [x] Touch updates only mtime when only mtime is supplied
 [x] Touch creates non existing file
```
