### PR TITLE
Bugfixes in mount and template commands

### DIFF
--- a/src/Command/FsMountCommand.php
+++ b/src/Command/FsMountCommand.php
@@ -93,7 +93,7 @@ class FsMountCommand extends Command
         $this->markChange();
 
         if ($this->checkMode()) {
-            $this->reportChange();
+            $this->reportChange($output);
             return 0;
         }
 
@@ -151,6 +151,6 @@ class FsMountCommand extends Command
             throw new ProcessFailedException($process);
         }
 
-        $this->reportChange();
+        $this->reportChange($output);
     }
 }

--- a/src/Command/FsTemplateCommand.php
+++ b/src/Command/FsTemplateCommand.php
@@ -72,7 +72,7 @@ class FsTemplateCommand extends Command
         $this->markChange();
 
         if ($this->checkMode()) {
-            $this->reportChange();
+            $this->reportChange($output);
             return 0;
         }
 

--- a/src/FstabLine.php
+++ b/src/FstabLine.php
@@ -141,23 +141,22 @@ class FstabLine
 
     public function render()
     {
-        switch ($this->getType()) {
-            case 'comment':
-                // leave untouched
-                return $this->content . "\n";
-            case 'empty':
-                return '';
-            case 'mount':
-                $o = $this->getFileSystem() . "\t";
-                $o .= $this->getMountPoint() . "\t";
-                $o .= $this->getFileSystemType() . "\t";
-                $o .= $this->getOptions() . "\t";
-                $o .= $this->getDump() . "\t";
-                $o .= $this->getPass();
-                return $o . "\n";
-            default:
-                throw new RuntimeException("Unsupported line type: " . $this->getType());
-                break;
+        if (!in_array($this->getType(), array('comment', 'empty', 'mount'))) {
+            throw new RuntimeException("Unsupported line type: " . $this->getType());
         }
+        if ($this->getType() === 'mount' && !$this->content) {
+            $this->content = implode(
+                "\t",
+                array(
+                    $this->getFileSystem(),
+                    $this->getMountPoint(),
+                    $this->getFileSystemType(),
+                    $this->getOptions(),
+                    $this->getDump(),
+                    $this->getPass(),
+                )
+            );
+        }
+        return $this->content . "\n";
     }
 }

--- a/src/FstabLine.php
+++ b/src/FstabLine.php
@@ -11,23 +11,23 @@ class FstabLine
     {
         return $this->content;
     }
-    
+
     public function setContent($content)
     {
         $this->content = $content;
-        
+
         if (trim($content, " \t")=='') {
             $this->type = 'empty';
+            return $this;
         }
         if (substr($content, 0, 1)=='#') {
             $this->type = 'comment';
-        }
-        if ($this->type) {
             return $this;
         }
+
         $this->type = 'mount';
-        
-        
+
+
         // Remove trailing tabs
         $line = trim($this->content, "\t");
         $line = str_replace(' ', "\t", $line);
@@ -35,7 +35,7 @@ class FstabLine
         $line = str_replace("\t\t\t", "\t", $line);
         $line = str_replace("\t\t\t", "\t", $line);
         $line = str_replace("\t\t", "\t", $line);
-        
+
         // Split into parts
         $part = explode("\t", $line);
         if (count($part)!=6) {
@@ -50,51 +50,51 @@ class FstabLine
 
         return $this;
     }
-    
+
     protected $type;
     public function getType()
     {
         return $this->type;
     }
-    
+
     public function setType($type)
     {
         $this->type = $type;
         return $this;
     }
-    
-    
+
+
     protected $fileSystem;
     public function getFileSystem()
     {
         return $this->fileSystem;
     }
-    
+
     public function setFileSystem($fileSystem)
     {
         $this->fileSystem = $fileSystem;
         return $this;
     }
-    
+
     protected $mountPoint;
     public function getMountPoint()
     {
         return $this->mountPoint;
     }
-    
+
     public function setMountPoint($mountPoint)
     {
         $this->mountPoint = $mountPoint;
         return $this;
     }
-    
+
     protected $fileSystemType;
-    
+
     public function getFileSystemType()
     {
         return $this->fileSystemType;
     }
-    
+
     public function setFileSystemType($fileSystemType)
     {
         $this->fileSystemType = $fileSystemType;
@@ -105,37 +105,37 @@ class FstabLine
     {
         return $this->options;
     }
-    
+
     public function setOptions($options)
     {
         $this->options = $options;
         return $this;
     }
-    
+
     protected $dump;
     public function getDump()
     {
         return $this->dump;
     }
-    
+
     public function setDump($dump)
     {
         $this->dump = $dump;
         return $this;
     }
-    
+
     protected $pass;
     public function getPass()
     {
         return $this->pass;
     }
-    
+
     public function setPass($pass)
     {
         $this->pass = $pass;
         return $this;
     }
-    
+
     public function render()
     {
         switch ($this->getType()) {

--- a/src/FstabLine.php
+++ b/src/FstabLine.php
@@ -27,19 +27,22 @@ class FstabLine
 
         $this->type = 'mount';
 
-
-        // Remove trailing tabs
-        $line = trim($this->content, "\t");
-        $line = str_replace(' ', "\t", $line);
-        // Remove multiple tabs
-        $line = str_replace("\t\t\t", "\t", $line);
-        $line = str_replace("\t\t\t", "\t", $line);
-        $line = str_replace("\t\t", "\t", $line);
+        // Normalise horizontal whitespace to single tabs
+        $line = str_replace(' ', "\t", trim($this->content, " \t"));
+        while (true) {
+            $prev = $line;
+            $line = str_replace("\t\t", "\t", $line);
+            if ($line === $prev) {
+                break;
+            }
+        }
 
         // Split into parts
         $part = explode("\t", $line);
         if (count($part)!=6) {
-            throw new RuntimeException("Line contains unexpected amount of parts: " . count($part) . ": [" . $line . "]");
+            throw new RuntimeException(
+                "Line contains unexpected amount of parts: " . count($part) . ": [" . $line . "]"
+            );
         }
         $this->setFileSystem($part[0]);
         $this->setMountPoint($part[1]);


### PR DESCRIPTION
- CheckableTrait.reportChange was being called without the required OutputInterface arg, resulting in PHP Fatal error
- Failure to update /etc/fstab when existing lines contain more than 6 spaces/tabs between fields

plus a minor change to FstabLine.render so that it leaves existing fstab lines unchanged.
